### PR TITLE
MOM-544 Add scripts to handle dockerising project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+config/test.json
+file-queue.gif
+.git/
+.travis.yml
+.jshintrc
+.jshintignore
+.gitignore
+node_modules/
+test/
+error/
+queue/
+working/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:dubnium-alpine
+
+ADD . /opt/openhim-mediator-file-queue
+
+WORKDIR /opt/openhim-mediator-file-queue
+
+RUN npm install
+
+CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM node:dubnium-alpine
 
 WORKDIR /opt/openhim-mediator-file-queue
 
-COPY package.json npm-shrinkwrap.json /opt/openhim-mediator-file-queue/
+COPY package.json npm-shrinkwrap.json ./
 
 RUN npm install
 
-COPY . /opt/openhim-mediator-file-queue
+COPY . .
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install
 
 COPY . /opt/openhim-mediator-file-queue
 
-CMD npm start
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:dubnium-alpine
 
-ADD . /opt/openhim-mediator-file-queue
+COPY . /opt/openhim-mediator-file-queue
 
 WORKDIR /opt/openhim-mediator-file-queue
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM node:dubnium-alpine
 
-COPY . /opt/openhim-mediator-file-queue
-
 WORKDIR /opt/openhim-mediator-file-queue
 
+COPY package.json npm-shrinkwrap.json /opt/openhim-mediator-file-queue/
+
 RUN npm install
+
+COPY . /opt/openhim-mediator-file-queue
 
 CMD npm start

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here is an example config file:
 Build container from project directory:
 
 ```sh
-docker build -t file-queue .
+docker build -t openhim-mediator-file-queue .
 ```
 
 Start container:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ docker build -t openhim-mediator-file-queue .
 Start container:
 
 ```sh
-docker run --name file-queue -p 4002:4002 file-queue
+docker run --name openhim-mediator-file-queue -p 4002:4002 openhim-mediator-file-queue
 ```
 
 Useful Flags:

--- a/README.md
+++ b/README.md
@@ -95,3 +95,27 @@ Here is an example config file:
   ]
 }
 ```
+
+## Development Startup
+
+### Docker
+
+> If connecting to a dockerised OpeHIM instance, change the host reference in the `/config/production.json` file to the OpenHIM's docker container name.
+
+Build container from project directory:
+
+```sh
+docker build -t file-queue .
+```
+
+Start container:
+
+```sh
+docker run --name file-queue -p 4002:4002 file-queue
+```
+
+Useful Flags:
+
+* `--network {openhim-network-name}` connect to a docker bridge network to allow communicating with dockerised OpenHIM
+* `--rm` to remove the container when stopped (Useful during development)
+* `-e NODE_TLS_REJECT_UNAUTHORIZED=0` if the using an OpenHIM instance with self signed certificates

--- a/config/development.json
+++ b/config/development.json
@@ -17,7 +17,7 @@
   "api": {
     "apiURL": "https://localhost:8080",
     "username": "root@openhim.org",
-    "password": "password"
+    "password": "openhim-password"
   },
   "statsd": {
     "host": "localhost",


### PR DESCRIPTION
The dockerfile contains instructions to create a
openhim-mediator-file-queue mediator docker image. The ignore file will
prevent unnecessary components being added to the context thereby
reducing the image size.
Dockerising this project is part of a larger effort to improve the
infrastructure of the MomConnect project though this component is
generic.

MOM-544