### PR TITLE
MOM-544: Set Dockerfile to not use Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:dubnium-alpine
+FROM node:dubnium
 
 WORKDIR /opt/openhim-mediator-file-queue
 


### PR DESCRIPTION
As this service makes use of cURL within the bash scripts for pasue/resume/repopulate requests

MOM-544