### PR TITLE
Properly update the OpenHIM transaction

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -126,18 +126,25 @@ function updateTx(res, body, apiOpts, transactionId) {
         status = 'Failed';
       }
 
+      // extract content type for properly converting payload to string
+      var [contentKey = 'Content-Type'] = Object.keys(res.headers).filter(k => /^content-type$/i.test(k));
+      var stringBody = res.headers[contentKey].search('json') ? JSON.stringify(body, null, 2) : body.toString();
+
       update = {
         status: status,
         response: {
           status: res.statusCode,
           headers: res.headers,
-          body: body.toString(),
+          body: stringBody,
           timestamp: new Date().toISOString()
         }
       };
     }
 
     var headers = MUtils.genAuthHeaders(apiOpts);
+    // specify custom content-type header for OpenHIM to process successfully
+    headers['content-type'] = 'application/json+openhim';
+
     Needle.put(apiOpts.apiURL + '/transactions/' + transactionId, update, {headers: headers, json: true}, function(err, apiRes, body) {
       if (err) {
         return Winston.error(err);


### PR DESCRIPTION
We need to set the content type header to be application/json+openhim for the mediator response to be processed correctly
We also need to stringify the payload differently for when its JSON compared to text or XML

OHIE-429