### PR TITLE
Allow empty content-type headers being returned

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -140,7 +140,7 @@ function updateTx(res, body, apiOpts, transactionId) {
 
       // extract content type for properly converting payload to string
       var [contentKey = 'Content-Type'] = Object.keys(res.headers).filter(k => /^content-type$/i.test(k));
-      var stringBody = ''
+      var stringBody = '';
       if (res.headers[contentKey]) {
         stringBody = res.headers[contentKey].search('json') ? JSON.stringify(body, null, 2) : body.toString();
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -140,7 +140,7 @@ function updateTx(res, body, apiOpts, transactionId) {
 
       // extract content type for properly converting payload to string
       var [contentKey = 'Content-Type'] = Object.keys(res.headers).filter(k => /^content-type$/i.test(k));
-      var stringBody = null
+      var stringBody = ''
       if (res.headers[contentKey]) {
         stringBody = res.headers[contentKey].search('json') ? JSON.stringify(body, null, 2) : body.toString();
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -140,7 +140,10 @@ function updateTx(res, body, apiOpts, transactionId) {
 
       // extract content type for properly converting payload to string
       var [contentKey = 'Content-Type'] = Object.keys(res.headers).filter(k => /^content-type$/i.test(k));
-      var stringBody = res.headers[contentKey].search('json') ? JSON.stringify(body, null, 2) : body.toString();
+      var stringBody = null
+      if (res.headers[contentKey]) {
+        stringBody = res.headers[contentKey].search('json') ? JSON.stringify(body, null, 2) : body.toString();
+      }
 
       update = {
         status: status,


### PR DESCRIPTION
If the downstream server doesnt respond with a payload, and therefor the statusCode is 204 (No Content), there wont be a Content-Type header
Previously this would throw an error trying to access the header that doesnt exist

MOM-636